### PR TITLE
小问题修正，ui提升

### DIFF
--- a/MoeLoaderDelta/Control/DownloadControl.xaml.cs
+++ b/MoeLoaderDelta/Control/DownloadControl.xaml.cs
@@ -235,22 +235,20 @@ namespace MoeLoaderDelta
             {
                 sPath = dlitem.LocalName.Substring(0, dlitem.LocalName.LastIndexOf("\\") + 1);
             }
-
             else
             {
-                if (!dlitem.LocalName.IsNullOrEmptyOrWhiteSpace() && dlitem.LocalName.Contains("_ugoira"))
-                {
-                    sPath = SaveLocation + "\\" + dlitem.Id + "\\";
-                }
+                sPath = SaveLocation
+                    + (IsSepSave ? "\\" + dlitem.Host : "")
+                   + (IsSscSave && !dlitem.SearchWord.IsNullOrEmptyOrWhiteSpace() ? "\\" + dlitem.SearchWord : "")
+                   + (IsSaSave ? "\\" + ReplaceInvalidPathChars(dlitem.Author) : "")
+                   + "\\";
 
-                else
-                {
-                    sPath = SaveLocation
-                      + (IsSepSave ? "\\" + dlitem.Host : "")
-                     + (IsSscSave && !dlitem.SearchWord.IsNullOrEmptyOrWhiteSpace() ? "\\" + dlitem.SearchWord : "")
-                     + (IsSaSave ? "\\" + ReplaceInvalidPathChars(dlitem.Author) : "")
-                     + "\\";
-                }
+                //Pixiv站动图，每个动图投稿都用ID号建一个文件夹装好
+                if (dlitem.Host == "pixiv" &&
+                    !dlitem.Url.IsNullOrEmptyOrWhiteSpace() &&
+                    dlitem.Url.Contains("_ugoira"))
+                    sPath = SaveLocation + "\\" + dlitem.Id + "\\";
+
                 if (!Directory.Exists(sPath))
                     Directory.CreateDirectory(sPath);
             }
@@ -612,7 +610,7 @@ namespace MoeLoaderDelta
             {
                 Dispatcher.Invoke(new VoidDel(delegate () { ExecuteDownloadListTask(DLWorkMode.AutoRetryAll); }));
             }
-            GC.Collect(2,GCCollectionMode.Optimized);
+            GC.Collect(2, GCCollectionMode.Optimized);
         }
 
         /// <summary>

--- a/MoeLoaderDelta/Control/DownloadControl.xaml.cs
+++ b/MoeLoaderDelta/Control/DownloadControl.xaml.cs
@@ -235,14 +235,22 @@ namespace MoeLoaderDelta
             {
                 sPath = dlitem.LocalName.Substring(0, dlitem.LocalName.LastIndexOf("\\") + 1);
             }
+
             else
             {
-                sPath = SaveLocation
-                    + (IsSepSave ? "\\" + dlitem.Host : "")
-                   + (IsSscSave && !dlitem.SearchWord.IsNullOrEmptyOrWhiteSpace() ? "\\" + dlitem.SearchWord : "")
-                   + (IsSaSave ? "\\" + ReplaceInvalidPathChars(dlitem.Author) : "")
-                   + "\\";
+                if (!dlitem.LocalName.IsNullOrEmptyOrWhiteSpace() && dlitem.LocalName.Contains("_ugoira"))
+                {
+                    sPath = SaveLocation + "\\" + dlitem.Id + "\\";
+                }
 
+                else
+                {
+                    sPath = SaveLocation
+                      + (IsSepSave ? "\\" + dlitem.Host : "")
+                     + (IsSscSave && !dlitem.SearchWord.IsNullOrEmptyOrWhiteSpace() ? "\\" + dlitem.SearchWord : "")
+                     + (IsSaSave ? "\\" + ReplaceInvalidPathChars(dlitem.Author) : "")
+                     + "\\";
+                }
                 if (!Directory.Exists(sPath))
                     Directory.CreateDirectory(sPath);
             }

--- a/MoeLoaderDelta/Control/ImgControl.xaml
+++ b/MoeLoaderDelta/Control/ImgControl.xaml
@@ -6,8 +6,8 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     x:Name="UserControl"
-    Width="170"
-    Height="190"
+    Width="184"
+    Height="204"
     Margin="6,10,6,10"
     mc:Ignorable="d">
     <!--  S: 160x183 L:310x333  -->

--- a/MoeLoaderDelta/Control/SearchControl.xaml.cs
+++ b/MoeLoaderDelta/Control/SearchControl.xaml.cs
@@ -78,11 +78,34 @@ namespace MoeLoaderDelta
         /// <param name="word"></param>
         public void AddUsedItem(string word)
         {
+            if (word != null && word.Trim().Length > 0 && word != "搜索")
+            {
+                if (usedItems.Contains(word))
+                {
+                    usedItems.Remove(word);
+                    usedItems.AddFirst(word);
+                }
+
+                else
+                {
+                    if (usedItems.Count > 30)
+                        usedItems.RemoveLast();
+                    usedItems.AddFirst(word);
+                }
+
+            }
+        }
+
+        /// <summary>
+        /// 从配置文件中加载搜索过的词
+        /// </summary>
+        /// <param name="word"></param>
+        public void LoadUsedItems(string word)
+        {
             if (word != null && word.Trim().Length > 0 && !usedItems.Contains(word) && word != "搜索")
             {
-                if (usedItems.Count > 30)
-                    usedItems.RemoveLast();
-                usedItems.AddFirst(word);
+                if (usedItems.Count < 30)
+                    usedItems.AddLast(word);
             }
         }
 

--- a/MoeLoaderDelta/MainWindow.xaml.cs
+++ b/MoeLoaderDelta/MainWindow.xaml.cs
@@ -487,7 +487,7 @@ namespace MoeLoaderDelta
                             {
                                 //if (word.Trim().Length > 0)
                                 //txtSearch.Items.Add(word);
-                                searchControl.AddUsedItem(word);
+                                searchControl.LoadUsedItems(word);
                             }
                         }
                         //if (!txtSearch.Items.Contains("thighhighs"))
@@ -842,7 +842,7 @@ namespace MoeLoaderDelta
                 //设图册页数
                 if (oriUrls.Count > 1)
                 {
-                    imgs[index].ImgP = c + 1 + "";
+                    imgs[index].ImgP = c + 0 + "";
                 }
                 string fileName = GenFileName(dlimg, oriUrls[c]);
                 string domain = SiteManager.Instance.Sites[nowSelectedIndex].ShortName;
@@ -1814,7 +1814,7 @@ namespace MoeLoaderDelta
                                 //设图册页数
                                 if (oriUrls.Count > 1)
                                 {
-                                    selectimg.ImgP = c + 1 + "";
+                                    selectimg.ImgP = c + 0 + "";
                                 }
 
                                 //url|文件名|域名|上传者|ID(用于判断重复)
@@ -1880,8 +1880,8 @@ namespace MoeLoaderDelta
                     if (img != null)
                     {
                         //如果比默认大小还小就用默认大小
-                        img.Width = smallx < 170 ? img.Width > 170 ? 170 : 170 : smallx;
-                        img.Height = smally < 190 ? img.Height > 190 ? 190 : 190 : smally;
+                        img.Width = smallx < 184 ? img.Width > 184 ? 184 : 184 : smallx;
+                        img.Height = smally < 204 ? img.Height > 204 ? 204 : 204 : smally;
                     }
                     //自适应评分数字区
                     img.brdScr.Width = img.Width / 4;
@@ -2082,7 +2082,7 @@ namespace MoeLoaderDelta
                         //设图册页数
                         if (oriUrls.Count > 1)
                         {
-                            imgs[i].ImgP = c + 1 + "";
+                            imgs[i].ImgP = c + 0 + "";
                         }
                         string fileName = GenFileName(dlimg, oriUrls[c]);
                         string domain = SiteManager.Instance.Sites[nowSelectedIndex].ShortName;
@@ -2104,6 +2104,9 @@ namespace MoeLoaderDelta
         /// <returns></returns>
         private string GenFileName(Img img, string url)
         {
+            //Pixiv站动图
+            if (img.PixivUgoira == true)
+                return img.Id.ToSafeString() + "_ugoira"+ img.ImgP;
             //namePatter
             string file = namePatter;
             if (string.IsNullOrWhiteSpace(file))

--- a/MoeSite/Img.cs
+++ b/MoeSite/Img.cs
@@ -18,6 +18,10 @@ namespace MoeLoaderDelta
     public class Img
     {
         /// <summary>
+        /// 是否为Pixiv站动图
+        /// </summary>
+        public bool PixivUgoira { get; set; }
+        /// <summary>
         /// 原图地址
         /// </summary>
         public string OriginalUrl { get; set; }
@@ -158,6 +162,7 @@ namespace MoeLoaderDelta
         /// </summary>
         public Img()
         {
+            PixivUgoira = false;
             Date = "NoDate";
             Desc = "";
             FileSize = "N/A";

--- a/SitePack/SitePixiv.cs
+++ b/SitePack/SitePixiv.cs
@@ -318,7 +318,7 @@ namespace SitePack
                         {
                             tempPageString.Add(Sweb.Get($"{SiteUrl}/ajax/user/{keyWord}/profile/illusts?{ids[i]}is_manga_top=0", proxy, shc));
                         }
-                        if(!tempPageString.Exists(string.IsNullOrWhiteSpace))
+                        if (!tempPageString.Exists(string.IsNullOrWhiteSpace))
                         {
                             //ROOT->body->works
                             //获取图片详细信息
@@ -766,10 +766,16 @@ namespace SitePack
                                 }
                             }
                         }
-                        catch { }
+                        catch (Exception ex)
+                        {
+                            throw ex;
+                        }
                     }
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    throw ex;
+                }
             });
 
             return img;

--- a/SitePack/SiteProvider.cs
+++ b/SitePack/SiteProvider.cs
@@ -14,6 +14,15 @@ namespace SitePack
                 $"{System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().CodeBase).Replace("file:\\", string.Empty)}\\SitePacks\\18x.txt"
                 );
 
+            sites.Add(new SitePixiv(SitePixiv.PixivSrcType.Author, proxy));
+            sites.Add(new SitePixiv(SitePixiv.PixivSrcType.Tag, proxy));
+            sites.Add(new SitePixiv(SitePixiv.PixivSrcType.TagFull, proxy));
+            sites.Add(new SitePixiv(SitePixiv.PixivSrcType.Day, proxy));
+            sites.Add(new SitePixiv(SitePixiv.PixivSrcType.Week, proxy));
+            sites.Add(new SitePixiv(SitePixiv.PixivSrcType.Month, proxy));
+            sites.Add(new SitePixiv(SitePixiv.PixivSrcType.Pid, proxy));
+            sites.Add(new SitePixiv(SitePixiv.PixivSrcType.PidPlus, proxy));
+
             sites.Add(new SiteLargeBooru(
                 "https://yande.re",
                 "https://yande.re/post.xml?page={0}&limit={1}&tags={2}", //XML
@@ -69,15 +78,6 @@ namespace SitePack
             sites.Add(new SiteMjvArt());
 
             sites.Add(new SiteWCosplay());
-
-            sites.Add(new SitePixiv(SitePixiv.PixivSrcType.Tag, proxy));
-            sites.Add(new SitePixiv(SitePixiv.PixivSrcType.TagFull, proxy));
-            sites.Add(new SitePixiv(SitePixiv.PixivSrcType.Author, proxy));
-            sites.Add(new SitePixiv(SitePixiv.PixivSrcType.Day, proxy));
-            sites.Add(new SitePixiv(SitePixiv.PixivSrcType.Week, proxy));
-            sites.Add(new SitePixiv(SitePixiv.PixivSrcType.Month, proxy));
-            sites.Add(new SitePixiv(SitePixiv.PixivSrcType.Pid, proxy));
-            sites.Add(new SitePixiv(SitePixiv.PixivSrcType.PidPlus, proxy));
 
             sites.Add(new SiteMiniTokyo(1));
             sites.Add(new SiteMiniTokyo(2));


### PR DESCRIPTION
1、修正了Pixiv有时一页会显示超多投稿的情况。
2、添加了Pixiv动图支持，下载的图片为原始图片帧。不是 XXXXXX_ugoira1920x1080.zip 那个压缩包。
3、修改了预览图显示尺寸，与Pixiv站页面一致。
4、修改了菜单中站点的排列顺序，将Pixiv [U]排在了第一位。
5、修正了每次重启程序时，搜索历史会被倒排的问题。